### PR TITLE
feat: codex cli integration for slack env and api

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
 - `p6df::modules::slack::deps()`
 - `p6df::modules::slack::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::slack::langs()`
 - `p6df::modules::slack::profile::off()`
 - `p6df::modules::slack::profile::on(profile, bot_token, app_token, team_id)`
@@ -58,17 +58,17 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
 - `p6df::modules::slack::cli::api(method, [json_payload={}])`
 - `p6df::modules::slack::cli::chatdelete(channel, timestamp)`
   - Args:
-    - channel - 
-    - timestamp - 
+    - channel -
+    - timestamp -
 - `p6df::modules::slack::cli::chatsend(channel, text)`
   - Args:
-    - channel - 
-    - text - 
+    - channel -
+    - text -
 - `p6df::modules::slack::cli::chatupdate(channel, timestamp, text)`
   - Args:
-    - channel - 
-    - timestamp - 
-    - text - 
+    - channel -
+    - timestamp -
+    - text -
 
 ## ENV
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+Install and configure Slack CLI + tokenized API helpers for shell and Codex usage.
 
 ## Contributing
 
@@ -35,16 +35,27 @@ TODO: Add a short summary of this module.
 
 ##### p6df-slack/init.zsh
 
+- `p6df::modules::slack::aliases::init()`
 - `p6df::modules::slack::deps()`
 - `p6df::modules::slack::init(_module, dir)`
   - Args:
     - _module - 
     - dir - 
+- `p6df::modules::slack::langs()`
+- `p6df::modules::slack::profile::off()`
+- `p6df::modules::slack::profile::on(profile, bot_token, app_token, team_id)`
+  - Args:
+    - profile -
+    - bot_token -
+    - app_token -
+    - team_id -
 
 #### p6df-slack/lib
 
 ##### p6df-slack/lib/cli.sh
 
+- `str str = p6df::modules::slack::cli::token()`
+- `p6df::modules::slack::cli::api(method, [json_payload={}])`
 - `p6df::modules::slack::cli::chatdelete(channel, timestamp)`
   - Args:
     - channel - 
@@ -58,6 +69,13 @@ TODO: Add a short summary of this module.
     - channel - 
     - timestamp - 
     - text - 
+
+## ENV
+
+- `SLACK_BOT_TOKEN`
+- `SLACK_CLI_TOKEN`
+- `SLACK_APP_TOKEN`
+- `SLACK_TEAM_ID`
 
 ## Hierarchy
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
 - `SLACK_CLI_TOKEN`
 - `SLACK_APP_TOKEN`
 - `SLACK_TEAM_ID`
+- `P6_DFZ_PROFILE_SLACK`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -9,6 +9,7 @@
 p6df::modules::slack::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
+    p6m7g8-dotfiles/p6df-js
     rockymadden/slack-cli
   )
 }
@@ -32,6 +33,88 @@ p6df::modules::slack::init() {
   p6_bootstrap "$dir"
 
   p6_path_if "$P6_DFZ_SRC_DIR/rockymadden/slack-cli/src"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::slack::langs()
+#
+#>
+######################################################################
+p6df::modules::slack::langs() {
+
+  p6_js_npm_global_install "@slack/cli"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::slack::aliases::init()
+#
+#>
+######################################################################
+p6df::modules::slack::aliases::init() {
+
+  p6_alias "scli" "slack"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::slack::profile::on(profile, bot_token, app_token, team_id)
+#
+#  Args:
+#	profile -
+#	bot_token -
+#	app_token -
+#	team_id -
+#
+#  Environment:	 P6_DFZ_PROFILE_SLACK SLACK_APP_TOKEN SLACK_BOT_TOKEN SLACK_CLI_TOKEN SLACK_TEAM_ID
+#>
+######################################################################
+p6df::modules::slack::profile::on() {
+  local profile="$1"
+  local bot_token="$2"
+  local app_token="${3:-}"
+  local team_id="${4:-}"
+
+  p6_env_export "P6_DFZ_PROFILE_SLACK" "$profile"
+  p6_env_export "SLACK_BOT_TOKEN" "$bot_token"
+  p6_env_export "SLACK_CLI_TOKEN" "$bot_token"
+
+  if p6_string_blank_NOT "$app_token"; then
+    p6_env_export "SLACK_APP_TOKEN" "$app_token"
+  fi
+
+  if p6_string_blank_NOT "$team_id"; then
+    p6_env_export "SLACK_TEAM_ID" "$team_id"
+  fi
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::slack::profile::off()
+#
+#  Environment:	 P6_DFZ_PROFILE_SLACK SLACK_APP_TOKEN SLACK_BOT_TOKEN SLACK_CLI_TOKEN SLACK_TEAM_ID
+#>
+######################################################################
+p6df::modules::slack::profile::off() {
+
+  p6_env_export_un P6_DFZ_PROFILE_SLACK
+  p6_env_export_un SLACK_BOT_TOKEN
+  p6_env_export_un SLACK_CLI_TOKEN
+  p6_env_export_un SLACK_APP_TOKEN
+  p6_env_export_un SLACK_TEAM_ID
 
   p6_return_void
 }

--- a/init.zsh
+++ b/init.zsh
@@ -10,7 +10,6 @@ p6df::modules::slack::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
     p6m7g8-dotfiles/p6df-js
-    rockymadden/slack-cli
   )
 }
 
@@ -31,8 +30,6 @@ p6df::modules::slack::init() {
   local dir="$2"
 
   p6_bootstrap "$dir"
-
-  p6_path_if "$P6_DFZ_SRC_DIR/rockymadden/slack-cli/src"
 
   p6_return_void
 }
@@ -84,6 +81,16 @@ p6df::modules::slack::profile::on() {
   local bot_token="$2"
   local app_token="${3:-}"
   local team_id="${4:-}"
+
+  if p6_string_blank "$profile"; then
+    p6_echo "error: profile must be provided" >&2
+    return 1
+  fi
+
+  if p6_string_blank "$bot_token"; then
+    p6_echo "error: bot_token must be provided" >&2
+    return 1
+  fi
 
   p6_env_export "P6_DFZ_PROFILE_SLACK" "$profile"
   p6_env_export "SLACK_BOT_TOKEN" "$bot_token"

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -33,10 +33,20 @@ p6df::modules::slack::cli::api() {
   local token
   token="$(p6df::modules::slack::cli::token)"
 
+  if [ -z "${method//[[:space:]]/}" ]; then
+    p6_echo "error: slack api method must be provided (e.g. 'chat.postMessage')" >&2
+    return 1
+  fi
+
+  if [ -z "${token//[[:space:]]/}" ]; then
+    p6_echo "error: slack token is not set; please export SLACK_BOT_TOKEN or SLACK_CLI_TOKEN" >&2
+    return 1
+  fi
+
   curl -sS -X POST "https://slack.com/api/${method}" \
     -H "Authorization: Bearer ${token}" \
     -H "Content-Type: application/json; charset=utf-8" \
-    --data "$json_payload" | jq .
+    --data-raw "$json_payload" | jq .
 }
 
 ######################################################################
@@ -48,7 +58,7 @@ p6df::modules::slack::cli::api() {
 #	channel -
 #	timestamp -
 #
-#  Environment:	 SLACK_CLI_TOKEN
+#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
 #>
 ######################################################################
 p6df::modules::slack::cli::chatdelete() {
@@ -75,7 +85,7 @@ p6df::modules::slack::cli::chatdelete() {
 #	channel -
 #	text -
 #
-#  Environment:	 SLACK_CLI_TOKEN
+#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
 #>
 ######################################################################
 p6df::modules::slack::cli::chatsend() {
@@ -103,7 +113,7 @@ p6df::modules::slack::cli::chatsend() {
 #	timestamp -
 #	text -
 #
-#  Environment:	 SLACK_CLI_TOKEN
+#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
 #>
 ######################################################################
 p6df::modules::slack::cli::chatupdate() {

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -2,6 +2,46 @@
 ######################################################################
 #<
 #
+# Function: str str = p6df::modules::slack::cli::token()
+#
+#  Returns:
+#	str - str
+#
+#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
+#>
+######################################################################
+p6df::modules::slack::cli::token() {
+  local token="${SLACK_BOT_TOKEN:-$SLACK_CLI_TOKEN}"
+  p6_return_str "$token"
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::slack::cli::api(method, [json_payload={}])
+#
+#  Args:
+#	method -
+#	json_payload -
+#
+#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
+#>
+######################################################################
+p6df::modules::slack::cli::api() {
+  local method="$1"
+  local json_payload="${2:-{}}"
+  local token
+  token="$(p6df::modules::slack::cli::token)"
+
+  curl -sS -X POST "https://slack.com/api/${method}" \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/json; charset=utf-8" \
+    --data "$json_payload" | jq .
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::slack::cli::chatdelete(channel, timestamp)
 #
 #  Args:
@@ -14,7 +54,8 @@
 p6df::modules::slack::cli::chatdelete() {
   local channel=$1
   local timestamp=$2
-  local token=$SLACK_CLI_TOKEN
+  local token
+  token="$(p6df::modules::slack::cli::token)"
 
   local msg=$(curl -s -X POST https://slack.com/api/chat.delete \
     --data-urlencode "as_user=true" \
@@ -40,7 +81,8 @@ p6df::modules::slack::cli::chatdelete() {
 p6df::modules::slack::cli::chatsend() {
   local channel=$1
   local text=$2
-  local token=$SLACK_CLI_TOKEN
+  local token
+  token="$(p6df::modules::slack::cli::token)"
 
   local msg=$(curl -s -X POST https://slack.com/api/chat.postMessage \
     --data-urlencode "as_user=true" \
@@ -68,7 +110,8 @@ p6df::modules::slack::cli::chatupdate() {
   local channel=$1
   local timestamp=$2
   local text=$3
-  local token=$SLACK_CLI_TOKEN
+  local token
+  token="$(p6df::modules::slack::cli::token)"
 
   local msg=$(curl -s -X POST https://slack.com/api/chat.update \
     --data-urlencode "as_user=true" \


### PR DESCRIPTION
## Summary
- add Slack CLI installation via npm for module bootstrap
- add Slack profile on/off functions for token environment management
- add generic Slack API wrapper and token fallback for existing chat helpers

## Validation
- bash -n init.zsh
- bash -n lib/cli.sh