### PR TITLE
chore: move slack-api helper from pep into p6df-slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
     - timestamp -
     - text -
 
+##### p6df-slack/lib/slack-api
+
+- `slack-api <method> [key=value ...]`
+
 ## ENV
 
 - `SLACK_BOT_TOKEN`
@@ -84,12 +88,13 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
 .
 ├── init.zsh
 ├── lib
-│   └── cli.sh
+│   ├── cli.sh
+│   └── slack-api
 ├── README.md
 └── share
     └── kb-shortcuts.png
 
-3 directories, 4 files
+3 directories, 5 files
 ```
 
 ## Author

--- a/init.zsh
+++ b/init.zsh
@@ -58,6 +58,7 @@ p6df::modules::slack::langs() {
 p6df::modules::slack::aliases::init() {
 
   p6_alias "scli" "slack"
+  p6_alias "slack-api" "$P6_DFZ_SRC_DIR/p6m7g8-dotfiles/p6df-slack/lib/slack-api"
 
   p6_return_void
 }

--- a/lib/slack-api
+++ b/lib/slack-api
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Slack API helper that always authenticates as philip@arkestro.com via 1Password.
+# Requires:
+#   - op CLI signed in
+#   - jq
+#
+# Usage:
+#   lib/slack-api auth.test
+#   lib/slack-api conversations.list types=public_channel,private_channel limit=20
+#   lib/slack-api users.list limit=50
+#   lib/slack-api conversations.history channel=C1234567890 limit=20
+#   lib/slack-api chat.postMessage channel=C1234567890 text='hello from cli'
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <method> [key=value ...]" >&2
+  exit 1
+fi
+
+if ! command -v op >/dev/null 2>&1; then
+  echo "op CLI is required" >&2
+  exit 1
+fi
+
+METHOD="$1"
+shift
+
+TOKEN="$(op item get 4eq3h7baqcgogfa2wmkmfjbdyy --fields label=credential --reveal)"
+API_URL="https://slack.com/api/${METHOD}"
+
+# read-only methods use GET, write methods use POST
+HTTP_METHOD="GET"
+if [[ "$METHOD" == chat.* || "$METHOD" == conversations.join || "$METHOD" == conversations.leave ]]; then
+  HTTP_METHOD="POST"
+fi
+
+if [[ "$HTTP_METHOD" == "GET" ]]; then
+  args=(--get)
+  for kv in "$@"; do
+    args+=(--data-urlencode "$kv")
+  done
+  curl -sS "$API_URL" -H "Authorization: Bearer ${TOKEN}" "${args[@]}" | jq .
+else
+  data=( )
+  for kv in "$@"; do
+    data+=(--data-urlencode "$kv")
+  done
+  curl -sS -X POST "$API_URL" -H "Authorization: Bearer ${TOKEN}" "${data[@]}" | jq .
+fi


### PR DESCRIPTION
## Summary
- move `scripts/slack-api` from pep into `lib/slack-api` in this module
- keep the helper executable and update inline usage examples
- add a `slack-api` alias and README entries for the new helper

## Testing
- bash -n lib/slack-api
