### PR TITLE
refactor(slack): no fallback, require SLACK_CLI_TOKEN path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
     - dir -
 - `p6df::modules::slack::langs()`
 - `p6df::modules::slack::profile::off()`
-- `p6df::modules::slack::profile::on(profile, env_or_token, [app_token], [team_id])`
+- `p6df::modules::slack::profile::on(profile, env_or_cli_token, [app_token], [team_id])`
   - Args:
     - profile -
     - bot_token -
@@ -76,7 +76,6 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
 
 ## ENV
 
-- `SLACK_BOT_TOKEN`
 - `SLACK_CLI_TOKEN`
 - `SLACK_APP_TOKEN`
 - `SLACK_TEAM_ID`

--- a/init.zsh
+++ b/init.zsh
@@ -66,30 +66,28 @@ p6df::modules::slack::aliases::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::slack::profile::on(profile, env_or_token, [app_token], [team_id])
+# Function: p6df::modules::slack::profile::on(profile, env_or_cli_token, [app_token], [team_id])
 #
 #  Args:
 #	profile -
-#	env_or_token -
+#	env_or_cli_token -
 #	OPTIONAL app_token -
 #	OPTIONAL team_id -
 #
-#  Environment:	 P6_DFZ_PROFILE_SLACK SLACK_APP_TOKEN SLACK_BOT_TOKEN SLACK_CLI_TOKEN SLACK_TEAM_ID
+#  Environment:	 P6_DFZ_PROFILE_SLACK SLACK_APP_TOKEN SLACK_CLI_TOKEN SLACK_TEAM_ID
 #>
 ######################################################################
 p6df::modules::slack::profile::on() {
   local profile="$1"
-  local env_or_token="$2"
+  local env_or_cli_token="$2"
   local app_token="${3:-}"
   local team_id="${4:-}"
 
-  local bot_token="$env_or_token"
-  local cli_token="$env_or_token"
+  local cli_token="$env_or_cli_token"
 
-  if p6_string_match_regex "$env_or_token" '(^|[[:space:]])export[[:space:]]+SLACK'; then
-    p6_run_code "$env_or_token"
-    bot_token="${SLACK_BOT_TOKEN:-}"
-    cli_token="${SLACK_CLI_TOKEN:-${SLACK_BOT_TOKEN:-}}"
+  if p6_string_match_regex "$env_or_cli_token" '(^|[[:space:]])export[[:space:]]+SLACK'; then
+    p6_run_code "$env_or_cli_token"
+    cli_token="${SLACK_CLI_TOKEN:-}"
     app_token="${SLACK_APP_TOKEN:-$app_token}"
     team_id="${SLACK_TEAM_ID:-$team_id}"
   fi
@@ -99,20 +97,13 @@ p6df::modules::slack::profile::on() {
     return 1
   fi
 
-  if p6_string_blank "$bot_token" && p6_string_blank "$cli_token"; then
-    p6_echo "error: slack token must be provided via token or SLACK_CLI_TOKEN/SLACK_BOT_TOKEN" >&2
+  if p6_string_blank "$cli_token"; then
+    p6_echo "error: SLACK_CLI_TOKEN must be provided" >&2
     return 1
   fi
 
   p6_env_export "P6_DFZ_PROFILE_SLACK" "$profile"
-
-  if p6_string_blank_NOT "$bot_token"; then
-    p6_env_export "SLACK_BOT_TOKEN" "$bot_token"
-  fi
-
-  if p6_string_blank_NOT "$cli_token"; then
-    p6_env_export "SLACK_CLI_TOKEN" "$cli_token"
-  fi
+  p6_env_export "SLACK_CLI_TOKEN" "$cli_token"
 
   if p6_string_blank_NOT "$app_token"; then
     p6_env_export "SLACK_APP_TOKEN" "$app_token"
@@ -130,13 +121,12 @@ p6df::modules::slack::profile::on() {
 #
 # Function: p6df::modules::slack::profile::off()
 #
-#  Environment:	 P6_DFZ_PROFILE_SLACK SLACK_APP_TOKEN SLACK_BOT_TOKEN SLACK_CLI_TOKEN SLACK_TEAM_ID
+#  Environment:	 P6_DFZ_PROFILE_SLACK SLACK_APP_TOKEN SLACK_CLI_TOKEN SLACK_TEAM_ID
 #>
 ######################################################################
 p6df::modules::slack::profile::off() {
 
   p6_env_export_un P6_DFZ_PROFILE_SLACK
-  p6_env_export_un SLACK_BOT_TOKEN
   p6_env_export_un SLACK_CLI_TOKEN
   p6_env_export_un SLACK_APP_TOKEN
   p6_env_export_un SLACK_TEAM_ID

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -7,11 +7,11 @@
 #  Returns:
 #	str - str
 #
-#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
+#  Environment:	 SLACK_CLI_TOKEN
 #>
 ######################################################################
 p6df::modules::slack::cli::token() {
-  local token="${SLACK_BOT_TOKEN:-$SLACK_CLI_TOKEN}"
+  local token="${SLACK_CLI_TOKEN:-}"
   p6_return_str "$token"
 }
 
@@ -24,7 +24,7 @@ p6df::modules::slack::cli::token() {
 #	method -
 #	json_payload -
 #
-#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
+#  Environment:	 SLACK_CLI_TOKEN
 #>
 ######################################################################
 p6df::modules::slack::cli::api() {
@@ -39,7 +39,7 @@ p6df::modules::slack::cli::api() {
   fi
 
   if [ -z "${token//[[:space:]]/}" ]; then
-    p6_echo "error: slack token is not set; please export SLACK_BOT_TOKEN or SLACK_CLI_TOKEN" >&2
+    p6_echo "error: slack token is not set; please export SLACK_CLI_TOKEN" >&2
     return 1
   fi
 
@@ -58,7 +58,7 @@ p6df::modules::slack::cli::api() {
 #	channel -
 #	timestamp -
 #
-#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
+#  Environment:	 SLACK_CLI_TOKEN
 #>
 ######################################################################
 p6df::modules::slack::cli::chatdelete() {
@@ -85,7 +85,7 @@ p6df::modules::slack::cli::chatdelete() {
 #	channel -
 #	text -
 #
-#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
+#  Environment:	 SLACK_CLI_TOKEN
 #>
 ######################################################################
 p6df::modules::slack::cli::chatsend() {
@@ -113,7 +113,7 @@ p6df::modules::slack::cli::chatsend() {
 #	timestamp -
 #	text -
 #
-#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
+#  Environment:	 SLACK_CLI_TOKEN
 #>
 ######################################################################
 p6df::modules::slack::cli::chatupdate() {


### PR DESCRIPTION
Removes fallback behavior and bot-token dependency; Slack auth now flows through SLACK_CLI_TOKEN/Slack ENV only.