### PR TITLE
feat(prompt): add slack prompt module

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
 - `p6df::modules::slack::langs()`
 - `p6df::modules::slack::profile::off()`
 - `p6df::modules::slack::profile::on(profile, env_or_cli_token, [app_token], [team_id])`
+- `str str = p6df::modules::slack::prompt::mod()`
   - Args:
     - profile -
     - bot_token -

--- a/init.zsh
+++ b/init.zsh
@@ -66,6 +66,37 @@ p6df::modules::slack::aliases::init() {
 ######################################################################
 #<
 #
+# Function: str str = p6df::modules::slack::prompt::mod()
+#
+#  Returns:
+#	str - str
+#
+#  Environment:	 P6_DFZ_PROFILE_SLACK SLACK_APP_TOKEN SLACK_CLI_TOKEN SLACK_TEAM_ID
+#>
+######################################################################
+p6df::modules::slack::prompt::mod() {
+  local str
+
+  if p6_string_blank_NOT "$P6_DFZ_PROFILE_SLACK"; then
+    str="slack:\t\t  $P6_DFZ_PROFILE_SLACK:"
+
+    if p6_string_blank_NOT "$SLACK_TEAM_ID"; then
+      str=$(p6_string_append "$str" "$SLACK_TEAM_ID" " ")
+    fi
+    if p6_string_blank_NOT "$SLACK_CLI_TOKEN"; then
+      str=$(p6_string_append "$str" "cli" "/")
+    fi
+    if p6_string_blank_NOT "$SLACK_APP_TOKEN"; then
+      str=$(p6_string_append "$str" "app" "/")
+    fi
+  fi
+
+  p6_return_str "$str"
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::slack::profile::on(profile, env_or_cli_token, [app_token], [team_id])
 #
 #  Args:


### PR DESCRIPTION
## Summary
- add `p6df::modules::slack::prompt::mod()`
- surface active Slack profile/team/token state in the prompt
- document the prompt function in the README

## Testing
- rely on GitHub Actions for repo validation