### PR TITLE
feat: add mcp() and mcp::env() hooks for Slack MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Contributing](#contributing)
 - [Code of Conduct](#code-of-conduct)
 - [Usage](#usage)
+  - [Aliases](#aliases)
   - [Functions](#functions)
 - [Hierarchy](#hierarchy)
 - [Author](#author)
@@ -17,7 +18,8 @@
 
 ## Summary
 
-Install and configure Slack CLI + tokenized API helpers for shell and Codex usage.
+p6df module for Slack: CLI aliases, profile switching (`SLACK_CLI_TOKEN`), and
+MCP server (`@modelcontextprotocol/server-slack`) with `SLACK_BOT_TOKEN` mapping.
 
 ## Contributing
 
@@ -29,6 +31,11 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
 
 ## Usage
 
+### Aliases
+
+- `scli` -> `slack`
+- `slack-api` -> `$P6_DFZ_SRC_DIR/p6m7g8-dotfiles/p6df-slack/lib/slack-api`
+
 ### Functions
 
 #### p6df-slack
@@ -39,48 +46,42 @@ Install and configure Slack CLI + tokenized API helpers for shell and Codex usag
 - `p6df::modules::slack::deps()`
 - `p6df::modules::slack::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
 - `p6df::modules::slack::langs()`
+- `p6df::modules::slack::mcp()`
+- `p6df::modules::slack::mcp::env()`
 - `p6df::modules::slack::profile::off()`
-- `p6df::modules::slack::profile::on(profile, env_or_cli_token, [app_token], [team_id])`
-- `str str = p6df::modules::slack::prompt::mod()`
+- `p6df::modules::slack::profile::on(profile, env_or_cli_token, [app_token=], [team_id=])`
   - Args:
-    - profile -
-    - bot_token -
-    - app_token -
-    - team_id -
+    - profile
+    - env_or_cli_token
+    - OPTIONAL app_token - []
+    - OPTIONAL team_id - []
+- `str str = p6df::modules::slack::prompt::mod()`
 
 #### p6df-slack/lib
 
 ##### p6df-slack/lib/cli.sh
 
-- `str str = p6df::modules::slack::cli::token()`
-- `p6df::modules::slack::cli::api(method, [json_payload={}])`
+- `p6df::modules::slack::cli::api(method, [json_payload={])`
+  - Args:
+    - method
+    - OPTIONAL json_payload - [{]
 - `p6df::modules::slack::cli::chatdelete(channel, timestamp)`
   - Args:
-    - channel -
-    - timestamp -
+    - channel
+    - timestamp
 - `p6df::modules::slack::cli::chatsend(channel, text)`
   - Args:
-    - channel -
-    - text -
+    - channel
+    - text
 - `p6df::modules::slack::cli::chatupdate(channel, timestamp, text)`
   - Args:
-    - channel -
-    - timestamp -
-    - text -
-
-##### p6df-slack/lib/slack-api
-
-- `slack-api <method> [key=value ...]`
-
-## ENV
-
-- `SLACK_CLI_TOKEN`
-- `SLACK_APP_TOKEN`
-- `SLACK_TEAM_ID`
-- `P6_DFZ_PROFILE_SLACK`
+    - channel
+    - timestamp
+    - text
+- `str token = p6df::modules::slack::cli::token()`
 
 ## Hierarchy
 

--- a/init.zsh
+++ b/init.zsh
@@ -22,7 +22,6 @@ p6df::modules::slack::deps() {
 #	_module -
 #	dir -
 #
-#  Environment:	 P6_DFZ_SRC_DIR
 #>
 ######################################################################
 p6df::modules::slack::init() {
@@ -53,6 +52,7 @@ p6df::modules::slack::langs() {
 #
 # Function: p6df::modules::slack::aliases::init()
 #
+#  Environment:	 P6_DFZ_SRC_DIR
 #>
 ######################################################################
 p6df::modules::slack::aliases::init() {
@@ -97,13 +97,13 @@ p6df::modules::slack::prompt::mod() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::slack::profile::on(profile, env_or_cli_token, [app_token], [team_id])
+# Function: p6df::modules::slack::profile::on(profile, env_or_cli_token, [app_token=], [team_id=])
 #
 #  Args:
 #	profile -
 #	env_or_cli_token -
-#	OPTIONAL app_token -
-#	OPTIONAL team_id -
+#	OPTIONAL app_token - []
+#	OPTIONAL team_id - []
 #
 #  Environment:	 P6_DFZ_PROFILE_SLACK SLACK_APP_TOKEN SLACK_CLI_TOKEN SLACK_TEAM_ID
 #>
@@ -161,6 +161,39 @@ p6df::modules::slack::profile::off() {
   p6_env_export_un SLACK_CLI_TOKEN
   p6_env_export_un SLACK_APP_TOKEN
   p6_env_export_un SLACK_TEAM_ID
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::slack::mcp()
+#
+#>
+######################################################################
+p6df::modules::slack::mcp() {
+
+  p6_js_npm_global_install "@modelcontextprotocol/server-slack"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::slack::mcp::env()
+#
+#  Environment:	 SLACK_BOT_TOKEN SLACK_CLI_TOKEN
+#>
+######################################################################
+p6df::modules::slack::mcp::env() {
+
+  if p6_string_blank_NOT "$SLACK_CLI_TOKEN"; then
+    p6_env_export "SLACK_BOT_TOKEN" "$SLACK_CLI_TOKEN"
+  else
+    p6_env_export_un "SLACK_BOT_TOKEN"
+  fi
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- `mcp()`: installs `@modelcontextprotocol/server-slack` for AI-driven Slack access
- `mcp::env()`: maps `SLACK_CLI_TOKEN` → `SLACK_BOT_TOKEN` for MCP server auth;
  standalone (not called from `profile::on/off`)

## Test plan

- [ ] `p6df mcp p6df-slack` installs `@modelcontextprotocol/server-slack`
- [ ] `p6df mcp::env p6df-slack` sets `SLACK_BOT_TOKEN` when `SLACK_CLI_TOKEN` is set
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)