### PR TITLE
fix: install slack-mcp-server via brew instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 
 ## Summary
 
-p6df module for Slack: CLI aliases, profile switching (`SLACK_CLI_TOKEN`), and
-MCP server (`@modelcontextprotocol/server-slack`) with `SLACK_BOT_TOKEN` mapping.
+p6df module for Slack: CLI tools (`slack-cli`), profile switching
+(`SLACK_BOT_TOKEN` via `SLACK_CLI_TOKEN`), and MCP server
+(`slack-mcp-server` via brew) for AI-driven workspace interactions.
 
 ## Contributing
 

--- a/init.zsh
+++ b/init.zsh
@@ -174,7 +174,7 @@ p6df::modules::slack::profile::off() {
 ######################################################################
 p6df::modules::slack::mcp() {
 
-  p6_js_npm_global_install "@modelcontextprotocol/server-slack"
+  p6df::core::homebrew::cli::brew::install slack-mcp-server
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary

- Replace `p6_js_npm_global_install "@modelcontextprotocol/server-slack"` with `p6df::core::homebrew::cli::brew::install slack-mcp-server` — a bottled Homebrew formula

## Test plan

- [ ] `p6df mcp` installs `slack-mcp-server` via brew

🤖 Generated with [Claude Code](https://claude.com/claude-code)