### PR TITLE
feat: switch MCP server to @modelcontextprotocol/server-slack npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 
 ## Summary
 
-Integrates Slack into the p6df shell framework. Provides profile-based token management
-(`SLACK_BOT_TOKEN` derived from `SLACK_CLI_TOKEN`), MCP server installation, and Slack API
-CLI helpers.
+p6df module for Slack: CLI tools (`slack-cli`), profile switching
+(`SLACK_BOT_TOKEN` derived from `SLACK_CLI_TOKEN`), and MCP server
+(`@modelcontextprotocol/server-slack` via npm) for AI-driven Slack interactions.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Summary
 
-p6df module for Slack: CLI tools (`slack-cli`), profile switching
+p6df module for Slack: CLI tools (`@slack/cli`), profile switching
 (`SLACK_BOT_TOKEN` derived from `SLACK_CLI_TOKEN`), and MCP server
 (`@modelcontextprotocol/server-slack` via npm) for AI-driven Slack interactions.
 


### PR DESCRIPTION
## Summary

- Switch `mcp()` from `slack-mcp-server` (brew) to `@modelcontextprotocol/server-slack` (npm)
- Aligns with active claude.json MCP server configuration

## Test plan
- [ ] `p6df mcp` installs `@modelcontextprotocol/server-slack` via npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)