### PR TITLE
fix(slack): fix profile::mod to return SLACK_TEAM_ID and SLACK_CLI_TOKEN

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -26,7 +26,7 @@ p6df::modules::slack::deps() {
 ######################################################################
 p6df::modules::slack::profile::mod() {
 
-  p6_return_words 'slack' "$"
+  p6_return_words 'slack' '$SLACK_TEAM_ID' '$SLACK_CLI_TOKEN'
 }
 
 ######################################################################


### PR DESCRIPTION
## What
Fix `profile::mod` to return `'$SLACK_TEAM_ID'` and `'$SLACK_CLI_TOKEN'` instead of a broken `"$"`.

## Why
The return value was broken — returning a literal `"$"` instead of the two env var references needed for Slack configuration. This caused the profile to not emit the expected env var words.

## Test plan
- Verified diff is correct
- Function now returns `slack $SLACK_TEAM_ID $SLACK_CLI_TOKEN` as expected

## Dependencies
None