### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::slack::deps()
+#
+#>
+######################################################################
 p6df::modules::slack::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -8,24 +14,18 @@ p6df::modules::slack::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::slack::mcp()
+#
+#>
+######################################################################
 p6df::modules::slack::mcp() {
 
   claude mcp add --transport http "claude.ai Slack" "https://mcp.slack.com/mcp"
 
   p6_return_void
 }
-######################################################################
-p6df::modules::slack::profile::mod() {
-
-  p6_return_words 'slack' '$SLACK_TEAM_ID' '$SLACK_CLI_TOKEN'
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::slack::deps()
-#
-#>
 ######################################################################
 #<
 #
@@ -37,8 +37,8 @@ p6df::modules::slack::profile::mod() {
 #  Environment:	 SLACK_TEAM_ID
 #>
 ######################################################################
-#<
-#
-# Function: p6df::modules::slack::mcp()
-#
-#>
+p6df::modules::slack::profile::mod() {
+
+  p6_return_words 'slack' '$SLACK_TEAM_ID' '$SLACK_CLI_TOKEN'
+}
+

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::slack::deps()
-#
-#>
-######################################################################
 p6df::modules::slack::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -13,6 +7,25 @@ p6df::modules::slack::deps() {
   )
 }
 
+######################################################################
+p6df::modules::slack::mcp() {
+
+  claude mcp add --transport http "claude.ai Slack" "https://mcp.slack.com/mcp"
+
+  p6_return_void
+}
+######################################################################
+p6df::modules::slack::profile::mod() {
+
+  p6_return_words 'slack' '$SLACK_TEAM_ID' '$SLACK_CLI_TOKEN'
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::slack::deps()
+#
+#>
 ######################################################################
 #<
 #
@@ -24,21 +37,8 @@ p6df::modules::slack::deps() {
 #  Environment:	 SLACK_TEAM_ID
 #>
 ######################################################################
-p6df::modules::slack::profile::mod() {
-
-  p6_return_words 'slack' '$SLACK_TEAM_ID' '$SLACK_CLI_TOKEN'
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::slack::mcp()
 #
 #>
-######################################################################
-p6df::modules::slack::mcp() {
-
-  claude mcp add --transport http "claude.ai Slack" "https://mcp.slack.com/mcp"
-
-  p6_return_void
-}


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None